### PR TITLE
Add possibility to subscribe to all event

### DIFF
--- a/ari/client.py
+++ b/ari/client.py
@@ -100,7 +100,7 @@ class Client(object):
                 except Exception as e:
                     self.exception_handler(e)
 
-    def run(self, apps):
+    def run(self, apps, subscribeAll="false"):
         """Connect to the WebSocket and begin processing messages.
 
         This method will block until all messages have been received from the
@@ -108,10 +108,12 @@ class Client(object):
 
         :param apps: Application (or list of applications) to connect for
         :type  apps: str or list of str
+        :param subscribeAll: Subscribe to all Asterisk events. If provided, the applications listed will be subscribed to all events, effectively disabling the application specific subscriptions. Default is 'false'.
+        :type  subscribeAll: boolean
         """
         if isinstance(apps, list):
             apps = ','.join(apps)
-        ws = self.swagger.events.eventWebsocket(app=apps)
+        ws = self.swagger.events.eventWebsocket(app=apps, subscribeAll=subscribeAll))
         self.websockets.add(ws)
         try:
             self.__run(ws)

--- a/ari/client.py
+++ b/ari/client.py
@@ -108,12 +108,10 @@ class Client(object):
 
         :param apps: Application (or list of applications) to connect for
         :type  apps: str or list of str
-        :param subscribeAll: Subscribe to all Asterisk events. If provided, the applications listed will be subscribed to all events, effectively disabling the application specific subscriptions. Default is 'false'.
-        :type  subscribeAll: boolean
         """
         if isinstance(apps, list):
             apps = ','.join(apps)
-        ws = self.swagger.events.eventWebsocket(app=apps, subscribeAll=subscribeAll))
+        ws = self.swagger.events.eventWebsocket(app=apps, subscribeAll=subscribeAll)
         self.websockets.add(ws)
         try:
             self.__run(ws)

--- a/examples/events.py
+++ b/examples/events.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+"""Brief example of using the Events API.
+
+This app will subscribe to all Asterisk event and bind each event to a method
+"""
+
+import ari
+
+client = ari.connect('http://localhost:8088/', 'hey', 'peekaboo')
+
+
+
+
+def on_DeviceStateChanged(event):    
+    name = event.get("device_state").get("name")
+    state = event.get("device_state").get("state")
+    timestamp = event.get("timestamp")
+    print("{} : Device {} is {}".format(timestamp, name, state))
+    
+def on_ContactStatusChange(event):      
+    name = "{}/{}".format(event.get("endpoint").get("technology"), event.get("endpoint").get("resource"))
+    contact_uri = event.get("contact_info").get("uri")
+    contact_status = event.get("contact_info").get("contact_status")
+    contact_roundtrip = event.get("contact_info").get("roundtrip_usec")
+    timestamp = event.get("timestamp")
+    
+    print("{} : Last Contact {} is {} at {} with {} ms".format(timestamp, name, contact_status, contact_uri, contact_roundtrip))
+
+def on_PeerStatusChange(event):
+    name = "{}/{}".format(event.get("endpoint").get("technology"), event.get("endpoint").get("resource"))
+    peer_status = event.get("peer").get("peer_status")
+    timestamp = event.get("timestamp")
+    
+    print("{} : Peer {} is {}".format(timestamp, name, peer_status))
+
+def on_ChannelDialplan(event):   
+    if event.get("dialplan_app") == "AppDial" :
+        timestamp = event.get("timestamp")
+        number_from = event.get("channel").get("caller").get("number")
+        number_to = event.get("channel").get("connected").get("number")
+        state = event.get("channel").get("state")           
+        
+        print("{} : {} AppDial {} : {}".format(timestamp, number_from, number_to, state))
+
+def on_Dial(event):
+    timestamp = event.get("timestamp")
+    number_from = event.get("caller").get("caller").get("number")
+    number_to = event.get("peer").get("caller").get("number")
+    state = event.get("dialstatus")          
+    
+    print("{} : {} Call {} : {}".format(timestamp, number_from, number_to, state))
+    
+def on_HangupRequest(event):
+    timestamp = event.get("timestamp")
+    number_from = event.get("channel").get("caller").get("number")
+    number_to = event.get("channel").get("connected").get("number")
+    
+    print("{} : {} Hangup {}".format(timestamp, number_from, number_to))  
+
+
+client.on_event("DeviceStateChanged", on_DeviceStateChanged)
+client.on_event("PeerStatusChange", on_PeerStatusChange)
+client.on_event("ContactStatusChange", on_ContactStatusChange)
+client.on_event("ChannelDialplan", on_ChannelDialplan)
+client.on_event("Dial", on_Dial)
+client.on_event("ChannelHangupRequest", on_HangupRequest)
+
+
+
+# Run the WebSocket
+client.run(apps="hello", subscribeAll="true")


### PR DESCRIPTION
https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Events+REST+API
eventWebsocket: GET /events
WebSocket connection for events.
Query parameters
app: string - (required) Applications to subscribe to.
Allows comma separated values.
subscribeAll: boolean - Subscribe to all Asterisk events. If provided, the applications listed will be subscribed to all events, effectively disabling the application specific subscriptions. Default is 'false'.